### PR TITLE
Add several option to support file_watcher and foreign language

### DIFF
--- a/src/file_watcher.py
+++ b/src/file_watcher.py
@@ -1,0 +1,10 @@
+import os
+
+WATCH_DIR   = "~/Documents/incoming_photos"
+SORTED_DIR  = "~/Documents/sorted_photos"
+FILTER_SORT = "~/Documents/sortphotos/src/sort_filter.py"
+
+filter_sort_cmd = 'python '+FILTER_SORT+' "${event}" '+SORTED_DIR+' '+WATCH_DIR
+fswatch_cmd     = 'fswatch -0 '+WATCH_DIR+' | while read -d "" event ; do '+filter_sort_cmd+' ; done ;'
+
+os.system(fswatch_cmd)

--- a/src/sort_filter.py
+++ b/src/sort_filter.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import fnmatch
+import errno
+
+FILTERS = ["*.db",".*"]
+REMOVE_FILTERED_FILES = True
+SORTPHOTOS  = "~/Documents/sortphotos/src/sortphotos.py"
+
+event = sys.argv[1]
+sorted_dir = sys.argv[2]
+watched_dir = sys.argv[3]
+
+print "sorted_dir:",sorted_dir
+print "event:",event
+
+def do_exit(event):
+	directory = os.path.split(event)[0]
+	if os.path.normcase(os.path.normpath(directory)) != os.path.normcase(os.path.normpath(watched_dir)):
+		try:
+		    os.rmdir(directory)
+		except OSError as ex:
+		    if ex.errno == errno.ENOTEMPTY:
+		        pass #directory is not empty, we don't remove it
+	sys.exit(0)
+
+if os.path.isdir(event):
+	print "event is directory: ignoring"
+	do_exit(event)
+
+if not os.path.isfile(event):
+	print "File has ever been processed."
+	do_exit(event)
+
+for _filter in FILTERS:
+	if fnmatch.fnmatch(os.path.split(event)[-1], _filter):
+		if REMOVE_FILTERED_FILES:
+			print "event match filter [%s]: deleting."%(_filter)
+			os.remove(event)
+		else:
+			print "event match filter [%s]: ignoring."%(_filter)
+		do_exit(event)
+
+print "Got valid event:"+event+" sorting..."
+
+sortphotos_cmd  = 'python '+SORTPHOTOS+' --sort %Y/%m-%B --rename %y%m%d_%H%M_%S "'+event+'" '+sorted_dir
+print "Applying command:"+sortphotos_cmd
+os.system(sortphotos_cmd)
+do_exit(event)

--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -21,7 +21,7 @@ except:
 import filecmp
 from datetime import datetime, timedelta
 import re
-
+import locale
 
 exiftool_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Image-ExifTool', 'exiftool')
 
@@ -474,9 +474,15 @@ def main():
                     default=None,
                     help='specify a restricted set of tags to search for date information\n\
     e.g., EXIF:CreateDate')
+    parser.add_argument('--set-locale', type=str,
+                    default=None,
+                    help='specify a locale like fr_FR fro french, useful to get month directory name in your own locale')
 
     # parse command line arguments
     args = parser.parse_args()
+
+    if args.set_locale:
+        locale.setlocale(locale.LC_TIME, args.set_locale)
 
     sortPhotos(args.src_dir, args.dest_dir, args.sort, args.rename, args.recursive,
         args.copy, args.test, not args.keep_duplicates, args.day_begins,

--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -357,6 +357,10 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
         # rename file if necessary
         filename = os.path.basename(src_file)
 
+        # patch to support foreign characters under python 2.x
+        if sys.version_info.major < 3:
+            dest_file = dest_file.decode('utf-8')
+
         if rename_format is not None:
             _, ext = os.path.splitext(filename)
             filename = date.strftime(rename_format) + ext

--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -188,17 +188,17 @@ class ExifTool(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.process.stdin.write("-stay_open\nFalse\n")
+        self.process.stdin.write(b"-stay_open\nFalse\n")
         self.process.stdin.flush()
 
     def execute(self, *args):
         args = args + ("-execute\n",)
-        self.process.stdin.write(str.join("\n", args))
+        self.process.stdin.write(str.join("\n", args).encode('utf-8'))
         self.process.stdin.flush()
         output = ""
         fd = self.process.stdout.fileno()
         while not output.rstrip(' \t\n\r').endswith(self.sentinel):
-            increment = os.read(fd, 4096)
+            increment = os.read(fd, 4096).decode('utf-8')
             if self.verbose:
                 sys.stdout.write(increment)
             output += increment


### PR DESCRIPTION
Hello,

These patch add several option I found usefull:
--set-locale fr_FR to force a locale, thus directory name created match the locale user need
--ignore to ignore a list of specific file like .* or .db (.* was ever supported in the script) but since I imported directory from windows got a lot of annoying Thumb.db files that were parsed by exiftool...
--remove-ignored-files option remove ignored files, the idea is to be able to get a clean source directory once file have been processed and moved
--remove-empty-dirs option to remove empty dirs in source dir once it has been processed

With all these option it is possible to put file in a dir and a script can process the dir. Once the dir is processed it can be completely cleaned up for next data incomming.

This bring us to the two new script file_watcher.py and sort_filter.py. The file_watcher is a script that use filewatch a cross platfrom directory watcher. Once file are put into the dir the sort_filter is called with the files added as argument, allowing to automagically sort your photos :)

disclaimer: This is initial version that do not use yet the new options.
A future version will come with new options support to improve speed and corner cases.

Laurent