### PR TITLE
Casting issue with float

### DIFF
--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -48,9 +48,9 @@ def parse_date_exif(date_string):
 
     # check if three entries, nonzero data, and no decimal (which occurs for timestamps with only time but no date)
     if len(date_entries) == 3 and date_entries[0] > '0000' and '.' not in ''.join(date_entries):
-        year = int(date_entries[0])
-        month = int(date_entries[1])
-        day = int(date_entries[2])
+        year = int(float(str(date_entries[0])))
+        month = int(float(str(date_entries[1])))
+        day = int(float(str(date_entries[2])))
     else:
         return None
 


### PR DESCRIPTION
Got this error:
Traceback (most recent call last):
  File "/usr/local/sortphotos/src/sortphotos.py", line 477, in <module>
    args.use_only_tags, not args.silent)
  File "/usr/local/sortphotos/src/sortphotos.py", line 307, in sortPhotos
    src_file, date, keys = get_oldest_timestamp(data, additional_groups_to_ignore, additional_tags_to_ignore)
  File "/usr/local/sortphotos/src/sortphotos.py", line 142, in get_oldest_timestamp
    exifdate = parse_date_exif(date)
  File "/usr/local/sortphotos/src/sortphotos.py", line 50, in parse_date_exif
    day = int(date_entries[2])
ValueError: invalid literal for int() with base 10: '06.00'

Propose to cast int with int(float(str
