### PR TITLE
Locale initialized to user local preferences

### DIFF
--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -362,7 +362,7 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
 
         if rename_format is not None:
             _, ext = os.path.splitext(filename)
-            filename = date.strftime(rename_format) + ext
+            filename = date.strftime(rename_format) + ext.lower()
 
         # setup destination file
         dest_file = os.path.join(dest_file, filename)

--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -21,7 +21,10 @@ except:
 import filecmp
 from datetime import datetime, timedelta
 import re
+import locale
 
+# Setting locale to the 'local' value
+locale.setlocale(locale.LC_ALL, '')
 
 exiftool_location = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'Image-ExifTool', 'exiftool')
 


### PR DESCRIPTION
I had a problem with the locale name of months. The fix is suggested in this [SO's answer](http://askubuntu.com/a/795588/171961)

As it is pointed in the[ 'locale' module documentation](https://docs.python.org/3.5/library/locale.html?highlight=locale#locale.setlocale): _This sets the locale for all categories to the user’s default setting (typically specified in the LANG environment variable)._
