### PR TITLE
add 'shell=True' to subprocess call to fix incompatibility

### DIFF
--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -184,7 +184,7 @@ class ExifTool(object):
     def __enter__(self):
         self.process = subprocess.Popen(
             ['perl', self.executable, "-stay_open", "True",  "-@", "-"],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, shell=True)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
Hi, I tried to use your app and it didn't work on my machine.  Got a subprocess error, and the fix (from SO) was to add shell=True to the subprocess call.  That worked.

Thanks for taking the time to write this program -- it's currently crunching away at my photo collection.