### PR TITLE
Python 3 compatibility

### DIFF
--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -2,14 +2,20 @@
 # encoding: utf-8
 """
 sortphotos.py
-
 Created on 3/2/2013
 Copyright (c) S. Andrew Ning. All rights reserved.
-
 """
 
 from __future__ import print_function
 from __future__ import with_statement
+from __future__ import unicode_literals
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+from builtins import str
+from builtins import object
 import subprocess
 import os
 import sys
@@ -131,7 +137,7 @@ def get_oldest_timestamp(data, additional_groups_to_ignore, additional_tags_to_i
         print('All relevant tags:')
 
     # run through all keys
-    for key in data.keys():
+    for key in list(data.keys()):
 
         # check if this key needs to be ignored, or is in the set of tags that must be used
         if (key not in ignore_tags) and (key.split(':')[0] not in ignore_groups) and 'GPS' not in key:
@@ -230,7 +236,6 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
         use_only_groups=None, use_only_tags=None, verbose=True):
     """
     This function is a convenience wrapper around ExifTool based on common usage scenarios for sortphotos.py
-
     Parameters
     ---------------
     src_dir : str
@@ -265,7 +270,6 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
         a list of tags that will be exclusived searched across for date info
     verbose : bool
         True if you want to see details of file processing
-
     """
 
     # some error checking
@@ -390,7 +394,7 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
 
         while True:
 
-            if (not test and os.path.isfile(dest_file)) or (test and dest_file in test_file_dict.keys()):  # check for existing name
+            if (not test and os.path.isfile(dest_file)) or (test and dest_file in list(test_file_dict.keys())):  # check for existing name
                 if test:
                     dest_compare = test_file_dict[dest_file]
                 else:

--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -376,7 +376,8 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
             filename = date.strftime(rename_format) + ext.lower()
 
         # setup destination file
-        dest_file = os.path.join(dest_file, filename.encode('utf-8'))
+        dest_file = os.path.join(dest_file.encode('utf-8'), filename.encode('utf-8'))
+        dest_file = dest_file.decode('utf-8')
         root, ext = os.path.splitext(dest_file)
 
         if verbose:


### PR DESCRIPTION
The proposed changes should let the script run with python version 3.x. One user recently reported the issue about a TypeError raised because python 3 can't mix byte and string in path components anymore. Another user recommended to use python 2.7.x instead (Issue #87). I didn't test every combination of parameters but the defaults and additional file renaming work.

Best regards,
Lukas
