### PR TITLE
Avoid mixing string and bytes

### DIFF
--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -374,7 +374,7 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
             filename = date.strftime(rename_format) + ext.lower()
 
         # setup destination file
-        dest_file = os.path.join(dest_file, filename.encode('utf-8'))
+        dest_file = os.path.join(dest_file, filename)
         root, ext = os.path.splitext(dest_file)
 
         if verbose:


### PR DESCRIPTION
This fixes a bug on Windows 10 with Python 3.7.2