### PR TITLE
Remove conflicting documentation for `-s` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you don't want to see details on file processing use the ``-s`` or ``--silent
 If you just want to simulate what is going to happen with your command use the ``-t`` or ``--test`` flag.  No files will be moved or copied, but all the moves will be simulated showing you how the files would be reorganized/renamed.  
 
 ## sort in directories
-By default folders are sorted by year then month, with both the month number and name.  So for example if cool_picture.jpg was taken on June 1, 2010 the resulting directory hierarchy will look like: 2010 > 06-Jun > cool_picture.jpg.  However, you can customize the sorting style almost anyway you want.  The script takes an optional argument ``-s`` or ``--sort``, which accepts a format string using the conventions described [here](https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior).  To separate by subdirectory, just use a forward slash (even if you are on Windows).    So for example, the default sorting behavior (2010/06-Jun) is equivalent to:
+By default folders are sorted by year then month, with both the month number and name.  So for example if cool_picture.jpg was taken on June 1, 2010 the resulting directory hierarchy will look like: 2010 > 06-Jun > cool_picture.jpg.  However, you can customize the sorting style almost anyway you want.  The script takes an optional argument ``--sort``, which accepts a format string using the conventions described [here](https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior).  To separate by subdirectory, just use a forward slash (even if you are on Windows).    So for example, the default sorting behavior (2010/06-Jun) is equivalent to:
 
     python sortphotos.py --sort %Y/%m-%b
 


### PR DESCRIPTION
The readme referenced the `-s` switch as an alias for both `--silent` and `--sort`. Appears it is only applicable to `--silent`, so I removed the reference in the Sort section of the readme.