### PR TITLE
Add support for Sidecar files

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ The first five are different EXIF data tags, and the last two are file stamp dat
 
 These five are commonly used tags, but there are a wide range of EXIF and other tags available (listed [here](http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/index.html)).  For the specific file types you use, you should rearrange or add the corresponding EXIF tags you need.   -->
 
+## restrict what file extensions to process by exiftool
+
+Pass a list of extensions to the Exiftool command, filtering out which files are processed. This is passed on to the `-ext` option in Exiftool
+
+For example only process jpgs and HEIC files in a directory structure
+
+    python sortphotos.py source destination --extensions jpg HEIC
+
+## move sidecar files
+
+Many programs create sidecar files for the image files. These sidecars need to have the same file name as the main file with a different extension.
+By using the `--sidecar-extensions` options, you can tell sortphotos to look for sidecars with the list of extensions and rename all sidecar files to match the main file.
+
+For example if you have  `Image_001.jpg` and `Image_001.json` both of these files would move together. Assume `Image_001.jpg` gets moved to `2000_01_01-22_22_22.jpg` then `Image_001.json` would get moved to `2000_01_01-22_22_22.json`
+
+The `--sidecar-extensions` is typically coupled with `--extensions`. Where `--extensions` lists the file type for the main files.
+
+A strong use case for this is managing Apple Live photos. Live photos have a `heic` and a `mov` file that must have the same name so need to move together. An example of that is
+
+    python sortphotos.py source destination --extensions HEIC --sidecar-extensions mov
+
 
 ## duplicate removal
 SortPhotos will *always* check to make sure something with the same file name doesn't already exist where it's trying to write, so that you don't unintentionally overwrite a file. It this occurs it will append a number on the end of the file.  So for example if photo.jpg was taken on June 1, 2010 but 2010 > June > photo.jpg already exists then the new file will be moved as photo_1.jpg and so on.  SortPhotos will go one step further and if it finds a file of the same name, it will then run a file compare to see if the files are actually the same.  If they are *exactly* the same, it will just skip the copy (or move) operation.  This will prevent you from having duplicate files.  However you have the option of turning this off (not the name comparison, that will always happen, just the weeding out of duplicates).  This option would be useful, for example, if you are copying over a bunch of new photos that you are sure don't already exist in your organized collection of photos.  Invoke the option ``--keep-duplicates`` in order to skip duplicate detection.

--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -223,12 +223,17 @@ class ExifTool(object):
 
 # ---------------------------------------
 
+def get_file_action(copy_files):
+    if copy_files:
+        return '(copy): '
+    else:
+        return '(move): '
 
 
 def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
         copy_files=False, test=False, remove_duplicates=True, day_begins=0,
         additional_groups_to_ignore=['File'], additional_tags_to_ignore=[],
-        use_only_groups=None, use_only_tags=None, verbose=True, keep_filename=False, extensions=None):
+        use_only_groups=None, use_only_tags=None, verbose=True, keep_filename=False, extensions=None, sidecar_extensions=[]):
     """
     This function is a convenience wrapper around ExifTool based on common usage scenarios for sortphotos.py
 
@@ -270,6 +275,8 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
         True if you want to see details of file processing
     extension: list(str)
         a list of file extensions to process
+    sidecar_extension: list(str)
+        a list of extensions that are sidecar files to be moved with main file
 
     """
 
@@ -385,10 +392,7 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
 
         if verbose:
             name = 'Destination '
-            if copy_files:
-                name += '(copy): '
-            else:
-                name += '(move): '
+            name += get_file_action(copy_files)
             print(name + dest_file)
 
 
@@ -423,19 +427,45 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
                 break
 
 
-        # finally move or copy the file
-        if test:
-            test_file_dict[dest_file] = src_file
+        files_to_move = {}
+        files_to_move[src_file]=dest_file
 
-        else:
+        ## look for sidecars
+        dest_root,dest_ext = os.path.splitext(dest_file)
+        src_root, src_ext = os.path.splitext(src_file)
+        
+        for ext in sidecar_extensions:
+            if not ext.startswith("."):
+                ext="." + ext
+            src_to_move = src_root + ext
+            dest_to_move = dest_root + ext
 
-            if fileIsIdentical:
-                continue  # ignore identical files
+            if os.path.isfile(src_to_move):
+                if verbose:
+                    verbose_str="Sidecar "
+                    verbose_str += get_file_action(copy_files)
+                    verbose_str += src_to_move
+                    verbose_str += " --> "
+                    verbose_str += dest_to_move
+                    print(verbose_str)
+                files_to_move[src_to_move]=dest_to_move
+
+
+        for src,dest in files_to_move.items():
+
+            # finally move or copy the file
+            if test:
+                test_file_dict[dest] = src
+
             else:
-                if copy_files:
-                    shutil.copy2(src_file, dest_file)
+
+                if fileIsIdentical:
+                    continue  # ignore identical files
                 else:
-                    shutil.move(src_file, dest_file)
+                    if copy_files:
+                        shutil.copy2(src, dest)
+                    else:
+                        shutil.move(src, dest)
 
 
 
@@ -497,6 +527,8 @@ def main():
     e.g., EXIF:CreateDate')
     parser.add_argument('--extensions', type=str, nargs='+', default=None,
                     help='List of explict extensions to process')
+    parser.add_argument('--sidecar-extensions', type=str, nargs='+', default=[],
+                    help='List of extensions that are sidecar files to the main file.')
 
     # parse command line arguments
     args = parser.parse_args()
@@ -504,7 +536,7 @@ def main():
     sortPhotos(args.src_dir, args.dest_dir, args.sort, args.rename, args.recursive,
         args.copy, args.test, not args.keep_duplicates, args.day_begins,
         args.ignore_groups, args.ignore_tags, args.use_only_groups,
-        args.use_only_tags, not args.silent, args.keep_filename, args.extensions)
+        args.use_only_tags, not args.silent, args.keep_filename, args.extensions, args.sidecar_extensions)
 
 if __name__ == '__main__':
     main()

--- a/src/sortphotos.py
+++ b/src/sortphotos.py
@@ -228,7 +228,7 @@ class ExifTool(object):
 def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
         copy_files=False, test=False, remove_duplicates=True, day_begins=0,
         additional_groups_to_ignore=['File'], additional_tags_to_ignore=[],
-        use_only_groups=None, use_only_tags=None, verbose=True, keep_filename=False):
+        use_only_groups=None, use_only_tags=None, verbose=True, keep_filename=False, extensions=None):
     """
     This function is a convenience wrapper around ExifTool based on common usage scenarios for sortphotos.py
 
@@ -268,6 +268,8 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
         a list of tags that will be exclusived searched across for date info
     verbose : bool
         True if you want to see details of file processing
+    extension: list(str)
+        a list of file extensions to process
 
     """
 
@@ -293,6 +295,9 @@ def sortPhotos(src_dir, dest_dir, sort_format, rename_format, recursive=False,
     else:
         args += ['-time:all']
 
+    if extensions:
+        for ext in extensions:
+            args += ['-ext',ext]
 
     if recursive:
         args += ['-r']
@@ -490,6 +495,8 @@ def main():
                     default=None,
                     help='specify a restricted set of tags to search for date information\n\
     e.g., EXIF:CreateDate')
+    parser.add_argument('--extensions', type=str, nargs='+', default=None,
+                    help='List of explict extensions to process')
 
     # parse command line arguments
     args = parser.parse_args()
@@ -497,7 +504,7 @@ def main():
     sortPhotos(args.src_dir, args.dest_dir, args.sort, args.rename, args.recursive,
         args.copy, args.test, not args.keep_duplicates, args.day_begins,
         args.ignore_groups, args.ignore_tags, args.use_only_groups,
-        args.use_only_tags, not args.silent, args.keep_filename)
+        args.use_only_tags, not args.silent, args.keep_filename, args.extensions)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This builds on top of #153 as the two features make sense independently.

The goal of this commit is always move sidecar files along with the main image. Many photo apps use sidecars as json or xml or xmp files. These sidecars need to match the main image file in name and just differ in extension. If `sortphotos` moves an image file the sidecar file should move (and rename with it). This PR introduces that with the introduction of the `--sidecar-extensions` option. When past the list of extensions are looked for, and if the side car exists it moves with the main file